### PR TITLE
make a simple install that copies 'dev' to 'prod'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ gnulib
 log
 nohup.out
 tests/example
+install/

--- a/buildenv
+++ b/buildenv
@@ -13,7 +13,9 @@ export ZOPEN_TYPE="GIT"
 export ZOPEN_BOOTSTRAP='skip'
 export ZOPEN_CONFIGURE='skip'
 export ZOPEN_MAKE='skip'
-export ZOPEN_INSTALL='skip'
+export ZOPEN_INSTALL='../install.sh'
+export ZOPEN_INSTALL_OPTS=''
+
 export ZOPEN_CHECK='../tests/basic.sh'
 export ZOPEN_CHECK_OPTS=''
 
@@ -35,4 +37,10 @@ zopen_check_results()
 zopen_append_to_env()
 {
   # echo envars outside of PATH, MANPATH, LIBPATH
+}
+
+zopen_get_version()
+{
+  info=$(./gnulib-tool --version)
+  echo "${info}" | head -n 1 | cut -d' ' -f6
 }

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# Script run to do a custom install
+#
+
+devdir="${PWD}"
+installdir="${ZOPEN_INSTALL_DIR}"
+
+echo "My Dir: ${devdir} Dev Dir: ${installdir}"
+
+if [ "${installdir}x" = "x" ]; then
+  echo "ZOPEN_INSTALL_DIR needs to be set to run this script"
+  exit 4
+fi
+
+rm -rf "${installdir}/"
+mkdir -p "${installdir}"
+/bin/cp -rpf "${devdir}/"  "${installdir}/"
+
+exit 0


### PR DESCRIPTION
This will be used by htopport so that it can generate a set of functions that aren't provided on z/OS

This is 'license safe' because htopport is also GPL2